### PR TITLE
Feat: axios instance 생성, api response, request type 정의

### DIFF
--- a/frontend/src/apis/authInstance.ts
+++ b/frontend/src/apis/authInstance.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { getAccessToken } from 'utils/localStorage';
 
 const baseUrl = process.env.BASE_URL;
 
@@ -6,8 +7,15 @@ export const authInstance = axios.create({
     baseURL: baseUrl,
     headers: {
         'Content-Type': 'application/json',
+        Authorization: `Bearer ${getAccessToken()}`,
     },
 });
 
-authInstance.interceptors.request.use();
-authInstance.interceptors.response.use();
+authInstance.interceptors.response.use(
+    (response) => {
+        return response;
+    },
+    (error) => {
+        // @TODO: 401 에러 처리
+    }
+);

--- a/frontend/src/apis/authInstance.ts
+++ b/frontend/src/apis/authInstance.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+const baseUrl = process.env.BASE_URL;
+
+export const authInstance = axios.create({
+    baseURL: baseUrl,
+    headers: {
+        'Content-Type': 'application/json',
+    },
+});
+
+authInstance.interceptors.request.use();
+authInstance.interceptors.response.use();

--- a/frontend/src/apis/defaultInstance.ts
+++ b/frontend/src/apis/defaultInstance.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+const baseUrl = process.env.BASE_URL;
+
+export const defaultInstance = axios.create({
+    baseURL: baseUrl,
+    headers: {
+        'Content-Type': 'application/json',
+    },
+});
+
+defaultInstance.interceptors.request.use();
+defaultInstance.interceptors.response.use();

--- a/frontend/src/interfaces/api/api.ts
+++ b/frontend/src/interfaces/api/api.ts
@@ -1,0 +1,5 @@
+export interface ApiResponse<T> {
+    message: string;
+    code: string;
+    data: T;
+}

--- a/frontend/src/interfaces/api/blog.ts
+++ b/frontend/src/interfaces/api/blog.ts
@@ -1,0 +1,8 @@
+import { IBlog } from 'interfaces/model';
+import { ApiResponse } from './api';
+
+export type getBlogInfoReqest = {
+    userId: string;
+};
+
+export type getBlogInfoResponse = ApiResponse<IBlog>;

--- a/frontend/src/interfaces/api/category.ts
+++ b/frontend/src/interfaces/api/category.ts
@@ -1,0 +1,8 @@
+import { CategoryListType } from 'interfaces/model';
+import { ApiResponse } from './api';
+
+export type getCategoryRequest = {
+    userId: string;
+};
+
+export type getCategoryResponse = ApiResponse<CategoryListType | []>;

--- a/frontend/src/interfaces/api/post.ts
+++ b/frontend/src/interfaces/api/post.ts
@@ -1,0 +1,21 @@
+import { IPostDetail, PostListType } from 'interfaces/model';
+import { ApiResponse } from './api';
+
+export type orderType = 'latest' | 'oldest' | 'popular';
+
+export type getPostListRequest = {
+    userId?: string;
+    categoryId?: string;
+    order?: orderType;
+    offset?: string;
+    limit?: string;
+};
+
+export type getPostListResponse = ApiResponse<PostListType>;
+
+export type getPostDetailRequest = {
+    userId: string;
+    postId: string;
+};
+
+export type getPostDetailResponse = ApiResponse<IPostDetail>;

--- a/frontend/src/interfaces/api/user.ts
+++ b/frontend/src/interfaces/api/user.ts
@@ -1,0 +1,8 @@
+import { IUser } from 'interfaces/model';
+import { ApiResponse } from './api';
+
+export type getUserInfoReqest = {
+    userId: string;
+};
+
+export type getUserInfoResponse = ApiResponse<IUser>;

--- a/frontend/src/interfaces/model/Post.ts
+++ b/frontend/src/interfaces/model/Post.ts
@@ -1,5 +1,6 @@
 import { POST_OPTION } from '../../constants/post';
 import { IAuthor } from './Author';
+import { CommentListType } from './Comment';
 
 export type PostOption = keyof typeof POST_OPTION;
 
@@ -9,13 +10,20 @@ export type PostOptionType = {
 
 export interface IPost {
     postId: number;
+    categoryId: string;
     categoryName: string;
     title: string;
     author: IAuthor;
     createdAt: string;
-    description: string;
     hit: number;
     excerpt: string;
     thumbnail: string;
+    content: string;
     numOfComments: number;
+}
+
+export type PostListType = IPost[];
+
+export interface IPostDetail extends IPost {
+    comments: CommentListType;
 }

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -1,0 +1,26 @@
+const accessTokenKey = 'ML_accessToken';
+const refreshTokenKey = 'ML_refreshToken';
+
+export const getAccessToken = (): string | null => {
+    return localStorage.getItem(accessTokenKey) || null;
+};
+
+export const getRefreshToken = (): string | null => {
+    return localStorage.getItem(refreshTokenKey) || null;
+};
+
+export const setAccessToken = (value: string) => {
+    localStorage.setItem(accessTokenKey, value);
+};
+
+export const setRefreshToken = (value: string) => {
+    localStorage.setItem(refreshTokenKey, value);
+};
+
+export const deleteAccessToken = () => {
+    localStorage.setItem(accessTokenKey, '');
+};
+
+export const deleteRefreshToken = () => {
+    localStorage.setItem(refreshTokenKey, '');
+};


### PR DESCRIPTION
## 이슈

- closed #29 
- closed #30 

## 작업 사항

- token이 필요한 instance와 필요하지 않은 instance를 분리하여 생성했습니다. (6ad29d90f11a9fa6b07379a2f1fe8c5fe5a646bc)
- api response, request type을 정의 후 types > api 폴더에 도메인 별로 작성했습니다. (b43ad03d1d24f488557e2d69aea7508e14a5b0b9)
